### PR TITLE
Fixed incorrectly marking "class" in "A::class" as a keyword.

### DIFF
--- a/src/php.grammar
+++ b/src/php.grammar
@@ -420,7 +420,7 @@ semicolon {
 
 @external specialize {Name} keywords from "./tokens" {
   abstract[@name=abstract], and[@name=LogicOp], array[@name=array], as[@name=as], Boolean,
-  break[@name=break], case[@name=case], catch[@name=catch], class[@name=class],
+  break[@name=break], case[@name=case], catch[@name=catch],
   clone[@name=clone], const[@name=const], continue[@name=continue], default[@name=default],
   declare[@name=declare], do[@name=do], echo[@name=echo], else[@name=else], elseif[@name=elseif],
   enddeclare[@name=enddeclare], endfor[@name=endfor], endforeach[@name=endforeach],
@@ -440,6 +440,7 @@ commaSep<content> { "" | content ("," content?)* }
 commaSep1<content> { content ("," content?)* }
 
 static[@dynamicPrecedence=1] { @extend[@name=static]<Name, "static" | "STATIC"> }
+class { @extend[@name=class]<Name, "class" | "CLASS"> }
 
 @external tokens expression from "./tokens" {
   castOpen[@name="("],

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,6 +1,6 @@
 import {ExternalTokenizer} from "@lezer/lr"
 import {
-  abstract, and, array, as, Boolean, _break, _case, _catch, _class, clone, _const, _continue,
+  abstract, and, array, as, Boolean, _break, _case, _catch, clone, _const, _continue,
   declare, _default, _do, echo, _else, elseif, enddeclare, endfor, endforeach, endif,
   endswitch, endwhile, _enum, _extends, final, _finally, fn, _for, foreach, from,
   _function, global, goto, _if, _implements, include, include_once, _instanceof,
@@ -22,7 +22,6 @@ const keywordMap = {
   break: _break,
   case: _case,
   catch: _catch,
-  class: _class,
   clone,
   const: _const,
   continue: _continue,

--- a/test/class.txt
+++ b/test/class.txt
@@ -344,3 +344,22 @@ Template(
     )
   )
 )
+
+# Class constant
+
+<?php
+
+A::class;
+
+==>
+
+Template(
+  TextInterpolation(PhpOpen),
+  ExpressionStatement(
+    ScopedExpression(
+      Name,
+      Name
+    ),
+    ";"
+  )
+)


### PR DESCRIPTION
Hi!

There's a special class constant "::class" in PHP (https://www.php.net/manual/en/language.oop5.constants.php). If you have an expression like "$a = SomeClass::class;", the "class" is currently wrongly rendered as a keyword. This pull request fixes the behavior so that the "::class" constant would be rendered as a generic Name token.

I spent the last 5 hours figuring out the best way to tackle this problem and this solution is the best thing I can think of, given my very limited knowledge of the lezer philosophy. If you think that there's a better way to fix this, please just give me a nudge in that direction and I'll update the code.