### PR TITLE
More accurate token group for the right side of the scoped expression

### DIFF
--- a/src/php.grammar
+++ b/src/php.grammar
@@ -324,7 +324,11 @@ DynamicVariable { "$" (VariableName | DynamicVariable) | "${" expression "}" }
 
 ParenthesizedExpression { "(" expression ")" }
 
-ScopedExpression { expression !scope "::" (Name | VariableName) }
+ScopedExpression { expression !scope "::" ClassMemberName }
+
+ClassMemberName {
+  Name | VariableName
+}
 
 ArgList {
   "(" commaSep<argument> ")"

--- a/test/class.txt
+++ b/test/class.txt
@@ -358,7 +358,7 @@ Template(
   ExpressionStatement(
     ScopedExpression(
       Name,
-      Name
+      ClassMemberName(Name)
     ),
     ";"
   )

--- a/test/declarations.txt
+++ b/test/declarations.txt
@@ -82,8 +82,8 @@ Template(
         Name,
         UseList(
           UseAsClause(Name, as, Visibility),
-          UseAsClause(ScopedExpression(Name, Name), as, Name),
-          UseAsClause(ScopedExpression(Name, Name), as, Name))))))
+          UseAsClause(ScopedExpression(Name, ClassMemberName(Name)), as, Name),
+          UseAsClause(ScopedExpression(Name, ClassMemberName(Name)), as, Name))))))
 
 # Namespace names in namespaces
 
@@ -213,7 +213,7 @@ Template(
       Parameter(
         VariableName,
         AssignOp,
-        ScopedExpression(Name, Name))),
+        ScopedExpression(Name, ClassMemberName(Name)))),
     Block(EchoStatement(echo,VariableName))))
 
 # Static variables in functions
@@ -387,7 +387,7 @@ Template(
     Attributes(Attribute(Name)),
     Attributes(Attribute(QualifiedName(NamespaceName(Name),Name))),
     Attributes(Attribute(Name,ArgList(Integer))),
-    Attributes(Attribute(Name,ArgList(ScopedExpression(Name,Name)))),
+    Attributes(Attribute(Name,ArgList(ScopedExpression(Name,ClassMemberName(Name))))),
     Attributes(Attribute(Name,ArgList(ArrayExpression(array, ValueList(Pair(String, String)))))),
     Attributes(Attribute(Name,ArgList(BinaryExpression(Integer, ArithOp, Integer)))),
     class,
@@ -465,13 +465,13 @@ Template(
               ),
               MatchBlock(
                 MatchArm(
-                  ScopedExpression(Name, Name),
-                  ScopedExpression(Name, Name),
+                  ScopedExpression(Name, ClassMemberName(Name)),
+                  ScopedExpression(Name, ClassMemberName(Name)),
                   String
                 ),
                 MatchArm(
-                  ScopedExpression(Name, Name),
-                  ScopedExpression(Name, Name),
+                  ScopedExpression(Name, ClassMemberName(Name)),
+                  ScopedExpression(Name, ClassMemberName(Name)),
                   String
                 )
               )

--- a/test/expressions.txt
+++ b/test/expressions.txt
@@ -141,7 +141,7 @@ m::self();
 Template(
   TextInterpolation(PhpOpen),
   ExpressionStatement(
-    CallExpression(ScopedExpression(Name, Name), ArgList)))
+    CallExpression(ScopedExpression(Name, ClassMemberName(Name)), ArgList)))
 
 # Symmetric array destructuring
 
@@ -262,7 +262,7 @@ Template(
       ),
       AssignOp,
       CallExpression(
-        ScopedExpression(Name, Name),
+        ScopedExpression(Name, ClassMemberName(Name)),
         ArgList(VariableName)
       )
     )
@@ -752,7 +752,7 @@ Template(
   ExpressionStatement(
     ThrowExpression(throw,
       CallExpression(
-        ScopedExpression(Name, Name),
+        ScopedExpression(Name, ClassMemberName(Name)),
         ArgList
       )
     )
@@ -876,15 +876,15 @@ Template(
         ParenthesizedExpression(VariableName),
         MatchBlock(
           MatchArm(
-            ScopedExpression(Name, Name), VariableName
+            ScopedExpression(Name, ClassMemberName(Name)), VariableName
             VariableName
           ),
           MatchArm(
-            ScopedExpression(Name, Name),
+            ScopedExpression(Name, ClassMemberName(Name)),
             CallExpression(Name, ArgList)
           ),
           MatchArm(
-            ScopedExpression(Name, Name)
+            ScopedExpression(Name, ClassMemberName(Name))
             CallExpression(MemberExpression(VariableName, Name), ArgList)
           ),
           MatchArm(

--- a/test/string.txt
+++ b/test/string.txt
@@ -149,7 +149,7 @@ Template(
       Interpolation(DynamicVariable(
         ScopedExpression(
           Name,
-          Name
+          ClassMemberName(Name)
         )
       )),
       EscapeSequence
@@ -160,7 +160,7 @@ Template(
       Interpolation(DynamicVariable(
         ScopedExpression(
           Name,
-          VariableName
+          ClassMemberName(VariableName)
         )
       )),
       EscapeSequence
@@ -329,7 +329,7 @@ Template(
   ),
   ExpressionStatement(
     String(
-      Interpolation(CallExpression(ScopedExpression(VariableName,Name), ArgList))
+      Interpolation(CallExpression(ScopedExpression(VariableName,ClassMemberName(Name)), ArgList))
     )
   ),
   ExpressionStatement(


### PR DESCRIPTION
This is a suggestion to add a designated token group for the right side of the ScopedExpression.

The goal is to be able to distinguish between the left and right sides of a scoped expression when describing the `styleTags` rules. This is needed to colorize properties and method calls in both objects and class uniformly. For example, take this code:

```
$anObject->property
Class::property
```

If I want to colorize the "property", I may use the following rules in `styleTags` (https://github.com/codemirror/lang-php/blob/main/src/php.ts#L48):
```
styleTags({
  ...
  "MemberExpression/Name": t.propertyName,
  "ScopedExpression/Name": t.propertyName,
  "CallExpression/MemberExpression/Name": t.function(t.propertyName),
  "CallExpression/ScopedExpression/Name": t.function(t.propertyName),
  ...
```

The side effect of this solution is that the `Name` may be in both the left and right parts of the expression. And while in 99% of cases of `MemberExpression` this can be mitigated by styling VariableName (that is very likely inside the left part), there's no workaround for ScopedExpression. Most of ScopedExpressions are just `ScopedExpression(Name, Name)`.

The proposed solution changes that to `ScopedExpression(Name, ClassMemberName(Name))`. This way you can describe `styleTags` as:

```
styleTags({
  ...
  "MemberExpression/Name": t.propertyName,
  "ScopedExpression/ClassMemberName/Name": t.propertyName,
  "CallExpression/MemberExpression/Name": t.function(t.propertyName),
  "CallExpression/ScopedExpression/ClassMemberName/Name": t.function(t.propertyName),
  ...
```
...and reach the desired effect.

If you think there's a better way, please suggest it and I'll send the updated code.